### PR TITLE
Allow interfacing by adding absolute paths on-the-fly

### DIFF
--- a/pysm_cmb.py
+++ b/pysm_cmb.py
@@ -9,7 +9,7 @@ def main(fname_config):
 	Config = ConfigParser.ConfigParser()
 	Config.read(fname_config)
 	out = output(Config._sections['GlobalParameters'])
-	a=Config.read('./ConfigFiles/'+Config.get('CMB','model')+'_config.ini')
+	a = read_conf_model('./ConfigFiles/'+Config.get('CMB','model')+'_config.ini',Config)
 	if a==[] :
 		print 'Couldn\'t find file '+'./ConfigFiles/'+Config.get('CMB','model')+'_config.ini'
 		exit(1)
@@ -29,7 +29,7 @@ def main(fname_config):
 		print('Using taylens to compute temperature map.')
 		print '----------------------------------------------------- \n'
 		synlmax = 8*out.nside #this used to be user-defined.
-		data = np.transpose(np.loadtxt(CMB.specs))
+		data = np.transpose(read_text_model(CMB.specs))
 		lmax_cl = len(data[0])+1
 		l = np.arange(int(lmax_cl+1))
 		synlmax = min(synlmax, l[-1])

--- a/pysm_freefree.py
+++ b/pysm_freefree.py
@@ -1,6 +1,6 @@
 import numpy as np
 import healpy as hp
-from pysm import scale_freqs, convert_units, output, component, add_frequency_decorrelation
+from pysm import scale_freqs, convert_units, output, component, add_frequency_decorrelation, read_conf_model
 import ConfigParser
 
 def scale_ff_pop(i_pop,npop,out,Config) :
@@ -36,7 +36,7 @@ def main(fname_config):
         Config.read(fname_config)
         out = output(Config._sections['GlobalParameters'])
 
-        a=Config_model.read('./ConfigFiles/'+Config.get('FreeFree','model')+'_config.ini')
+	a = read_conf_model('./ConfigFiles/'+Config.get('FreeFree','model')+'_config.ini',Config_model)
 	if a==[] :
 		print 'Couldn\'t find file '+'./ConfigFiles/'+Config.get('FreeFree','model')+'_config.ini'
 		exit(1)

--- a/pysm_spinningdust.py
+++ b/pysm_spinningdust.py
@@ -1,6 +1,6 @@
 import numpy as np
 import healpy as hp
-from pysm import scale_freqs, convert_units, component, output, add_frequency_decorrelation
+from pysm import scale_freqs, convert_units, component, output, add_frequency_decorrelation, read_conf_model
 import ConfigParser
 
 def scale_spdust_pop(i_pop,npop,out,Config) :
@@ -53,7 +53,7 @@ def main(fname_config):
     Config.read(fname_config)
     out = output(Config._sections['GlobalParameters'])
 
-    a=Config_model.read('./ConfigFiles/'+Config.get('SpinningDust','model')+'_config.ini')
+    a = read_conf_model('./ConfigFiles/'+Config.get('SpinningDust','model')+'_config.ini',Config_model)
     if a==[] :
         print 'Couldn\'t find file '+'./ConfigFiles/'+Config.get('SpinningDust','model')+'_config.ini'
         exit(1)

--- a/pysm_synchrotron.py
+++ b/pysm_synchrotron.py
@@ -1,6 +1,6 @@
 import numpy as np
 import healpy as hp
-from pysm import scale_freqs, convert_units, component, output, add_frequency_decorrelation
+from pysm import scale_freqs, convert_units, component, output, add_frequency_decorrelation, read_conf_model
 import ConfigParser
 
 def scale_synch_pop(i_pop,npop,out,Config) :
@@ -45,7 +45,7 @@ def main(fname_config):
 	Config.read(fname_config)
 	out = output(Config._sections['GlobalParameters'])
 
-	a=Config_model.read('./ConfigFiles/'+Config.get('Synchrotron','model')+'_config.ini')
+	a = read_conf_model('./ConfigFiles/'+Config.get('Synchrotron','model')+'_config.ini',Config_model)
 	if a==[] :
 		print 'Couldn\'t find file'+' ./ConfigFiles/'+Config.get('Synchrotron','model')+'_config.ini'
 		exit(1)

--- a/pysm_thermaldust.py
+++ b/pysm_thermaldust.py
@@ -1,6 +1,6 @@
 import numpy as np
 import healpy as hp
-from pysm import scale_freqs, convert_units, output, component, add_frequency_decorrelation
+from pysm import scale_freqs, convert_units, output, component, add_frequency_decorrelation, read_conf_model
 import ConfigParser
 
 def scale_dust_pop(i_pop,npop,out,Config):
@@ -37,7 +37,7 @@ def main(fname_config):
 	Config.read(fname_config)
 	out = output(Config._sections['GlobalParameters'])
 
-	a=Config_model.read('./ConfigFiles/'+Config.get('ThermalDust','model')+'_config.ini')
+	a = read_conf_model('./ConfigFiles/'+Config.get('ThermalDust','model')+'_config.ini',Config_model)
 	if a==[] :
 		print 'Couldn\'t find file '+'./ConfigFiles/'+Config.get('ThermalDust','model')+'_config.ini'
 		exit(1)


### PR DESCRIPTION
Hi!

The following changes have been made to ease the interfacing with other codes.
It transforms on-the-fly the relative paths for data into absolute paths.
The PySM path is determined from the sys.path. This is probably not ideal - ideally the user should enter manually his/her favorite path in the ini file - but it works (and I didn't want to change too many things).

Julien